### PR TITLE
Support external BDOS files for PC/M

### DIFF
--- a/src/jkcemu/base/EmuUtil.java
+++ b/src/jkcemu/base/EmuUtil.java
@@ -1,5 +1,6 @@
 /*
  * (c) 2008-2013 Jens Mueller
+ * (c) 2014-2015 Stephan Linz
  *
  * Kleincomputer-Emulator
  *
@@ -1312,6 +1313,12 @@ public class EmuUtil
   public static javax.swing.filechooser.FileFilter getRMCFileFilter()
   {
     return getFileFilter( "RBASIC-Maschinencodedateien (*.rmc)", "rmc" );
+  }
+
+
+  public static javax.swing.filechooser.FileFilter getRAMFileFilter()
+  {
+    return getFileFilter( "RAM-Dateien (*.bin; *.ram)", "ram", "bin" );
   }
 
 

--- a/src/jkcemu/base/RAMFileSettingsFld.java
+++ b/src/jkcemu/base/RAMFileSettingsFld.java
@@ -1,0 +1,229 @@
+/*
+ * (c) 2010-2011 Jens Mueller
+ * (c) 2014-2015 Stephan Linz
+ *
+ * Kleincomputer-Emulator
+ *
+ * Komponente fuer die Auswahl einer Datei
+ * Die Komponente enthaelt ein Label, ein Textfeld mit dem Dateinamen
+ * sowie zwei Knoepfen zum Auswaehlen und entfernen der Datei
+ */
+
+package jkcemu.base;
+
+import java.awt.*;
+import java.io.File;
+import java.lang.*;
+import java.util.*;
+import javax.swing.*;
+import javax.swing.event.*;
+import jkcemu.Main;
+import jkcemu.base.*;
+
+
+public class RAMFileSettingsFld extends AbstractSettingsFld
+{
+  private java.util.List<ChangeListener> changeListeners;
+  private JLabel                         label;
+  private FileNameFld                    fileNameFld;
+  private JButton                        btnSelect;
+  private JButton                        btnRemove;
+
+
+  public RAMFileSettingsFld(
+			SettingsFrm settingsFrm,
+                        String      propPrefix,
+			String      labelText )
+  {
+    super( settingsFrm, propPrefix );
+    setLayout( new GridBagLayout() );
+
+    GridBagConstraints gbc = new GridBagConstraints(
+					0, 0,
+					GridBagConstraints.REMAINDER, 1,
+					0.0, 0.0,
+					GridBagConstraints.WEST,
+					GridBagConstraints.NONE,
+					new Insets( 0, 0, 0, 0 ),
+					0, 0 );
+
+    this.label = new JLabel( labelText );
+    add( this.label, gbc );
+
+    this.fileNameFld = new FileNameFld();
+    gbc.fill         = GridBagConstraints.HORIZONTAL;
+    gbc.weightx      = 1.0;
+    gbc.gridwidth    = 1;
+    gbc.gridy++;
+    add( this.fileNameFld, gbc );
+
+    this.btnSelect = createImageButton(
+				"/images/file/open.png",
+				"RAM-Datei ausw\u00E4hlen" );
+    gbc.fill        = GridBagConstraints.NONE;
+    gbc.weightx     = 0.0;
+    gbc.insets.left = 5;
+    gbc.gridx++;
+    add( this.btnSelect, gbc );
+
+    this.btnRemove = createImageButton(
+				"/images/file/delete.png",
+				"RAM-Datei entfernen" );
+    this.btnRemove.setEnabled( false );
+    gbc.gridx++;
+    add( this.btnRemove, gbc );
+
+    enableFileDrop( this.fileNameFld );
+  }
+
+
+  public synchronized void addChangeListener( ChangeListener listener )
+  {
+    if( this.changeListeners == null ) {
+      this.changeListeners = new ArrayList<ChangeListener>();
+    }
+    this.changeListeners.add( listener );
+  }
+
+
+  public File getFile()
+  {
+    return this.fileNameFld.getFile();
+  }
+
+
+  public synchronized void removeChangeListener( ChangeListener listener )
+  {
+    if( this.changeListeners != null )
+      this.changeListeners.remove( listener );
+  }
+
+
+  public void setFile( File file )
+  {
+    boolean differs = true;
+    File    oldFile = this.fileNameFld.getFile();
+    if( (file != null) && (oldFile != null) ) {
+      if( file.getPath().equals( oldFile.getPath() ) ) {
+	differs = false;
+      }
+    } else {
+      if( (file == null) && (oldFile == null) ) {
+	differs = false;
+      }
+    }
+    if( differs ) {
+      this.fileNameFld.setFile( file );
+      this.btnRemove.setEnabled( (file != null) && this.label.isEnabled() );
+      if( file != null ) {
+	Main.setLastFile( file, "ram" );
+      }
+      fireDataChanged();
+    }
+  }
+
+
+  public void setFileName( String fileName )
+  {
+    File file = null;
+    if( fileName != null ) {
+      if( !fileName.isEmpty() ) {
+	file = new File( fileName );
+      }
+    }
+    setFile( file );
+  }
+
+
+  public void setLabelText( String text )
+  {
+    this.label.setText( text );
+  }
+
+
+	/* --- ueberschriebene Methoden --- */
+
+  @Override
+  public void applyInput(
+                Properties props,
+                boolean    selected ) throws UserInputException
+  {
+    File file = this.fileNameFld.getFile();
+    EmuUtil.setProperty(
+		props,
+		this.propPrefix + "file",
+                file != null ? file.getPath() : null );
+  }
+
+
+  @Override
+  protected boolean doAction( EventObject e )
+  {
+    boolean rv  = false;
+    Object  src = e.getSource();
+    if( src == this.btnSelect ) {
+      File file = selectFile(
+			"RAM-Datei ausw\u00E4hlen",
+			"ram",
+			this.fileNameFld.getFile(),
+			EmuUtil.getRAMFileFilter() );
+      if( file != null ) {
+	setFile( file );
+      }
+      rv = true;
+    }
+    else if( src == this.btnRemove ) {
+      setFile( null );
+      this.btnRemove.setEnabled( false );
+      rv = true;
+    }
+    return rv;
+  }
+
+
+  @Override
+  protected boolean fileDropped( Component c, File file )
+  {
+    boolean rv = false;
+    if( file != null ) {
+      setFile( file );
+      rv = true;
+    }
+    return rv;
+  }
+
+
+  @Override
+  protected void fireDataChanged()
+  {
+    super.fireDataChanged();
+    synchronized( this ) {
+      if( this.changeListeners != null ) {
+	for( ChangeListener listener : this.changeListeners ) {
+	  listener.stateChanged( new ChangeEvent( this ) );
+	}
+      }
+    }
+  }
+
+
+  @Override
+  public void setEnabled( boolean state )
+  {
+    super.setEnabled( state );
+    this.label.setEnabled( state );
+    this.fileNameFld.setEnabled( state );
+    this.btnSelect.setEnabled( state );
+    this.btnRemove.setEnabled( state && (this.fileNameFld.getFile() != null) );
+  }
+
+
+  @Override
+  public void updFields( Properties props )
+  {
+    this.fileNameFld.setFileName(
+	EmuUtil.getProperty( props, this.propPrefix + "file" ) );
+    this.btnRemove.setEnabled(
+	this.label.isEnabled() && (this.fileNameFld.getFile() != null) );
+  }
+}

--- a/src/jkcemu/emusys/PCM.java
+++ b/src/jkcemu/emusys/PCM.java
@@ -704,7 +704,7 @@ public class PCM extends EmuSys implements
     }
     if( EmuUtil.getBooleanProperty(
 			props,
-			"jkcemu.pcm.auto_load_bdos",
+			"jkcemu.pcm.bdos.autoload",
 			true ) )
     {
       if( bdos == null ) {

--- a/src/jkcemu/emusys/etc/PCMSettingsFld.java
+++ b/src/jkcemu/emusys/etc/PCMSettingsFld.java
@@ -1,5 +1,6 @@
 /*
  * (c) 2011 Jens Mueller
+ * (c) 2014-2015 Stephan Linz
  *
  * Kleincomputer-Emulator
  *
@@ -22,6 +23,7 @@ public class PCMSettingsFld extends AbstractSettingsFld
   private JRadioButton       btnRF64x16;
   private JRadioButton       btnFDC64x16;
   private JRadioButton       btnFDC80x24;
+  private RAMFileSettingsFld fldAltBDOS;
   private ROMFileSettingsFld fldAltROM;
   private ROMFileSettingsFld fldAltFont;
 
@@ -83,6 +85,13 @@ public class PCMSettingsFld extends AbstractSettingsFld
     gbc.gridy++;
     add( new JSeparator(), gbc );
 
+    this.fldAltBDOS = new RAMFileSettingsFld(
+		settingsFrm,
+		propPrefix + "bdos.",
+		"Alternative RAM-Datei f\u00FCr BDOS:" );
+    gbc.gridy++;
+    add( this.fldAltBDOS, gbc );
+
     this.fldAltROM = new ROMFileSettingsFld(
 		settingsFrm,
 		propPrefix + "rom.",
@@ -120,6 +129,7 @@ public class PCMSettingsFld extends AbstractSettingsFld
 		props,
 		this.propPrefix + "bdos.autoload",
 		this.btnAutoLoadBDOS.isSelected() );
+    this.fldAltBDOS.applyInput( props, selected );
     this.fldAltROM.applyInput( props, selected );
     this.fldAltFont.applyInput( props, selected );
   }
@@ -169,6 +179,7 @@ public class PCMSettingsFld extends AbstractSettingsFld
 				props,
 				this.propPrefix + "bdos.autoload",
 				true ) );
+    this.fldAltBDOS.updFields( props );
     this.fldAltROM.updFields( props );
     this.fldAltFont.updFields( props );
     updAutoLoadBDOSFieldEnabled();
@@ -180,6 +191,7 @@ public class PCMSettingsFld extends AbstractSettingsFld
   private void updAutoLoadBDOSFieldEnabled()
   {
     this.btnAutoLoadBDOS.setEnabled( this.btnRF64x16.isSelected() );
+    this.fldAltBDOS.setEnabled( this.btnRF64x16.isSelected() );
   }
 }
 

--- a/src/jkcemu/emusys/etc/PCMSettingsFld.java
+++ b/src/jkcemu/emusys/etc/PCMSettingsFld.java
@@ -118,7 +118,7 @@ public class PCMSettingsFld extends AbstractSettingsFld
 		fdc80x24 ? "80x24" : "64x16" );
     EmuUtil.setProperty(
 		props,
-		this.propPrefix + "auto_load_bdos",
+		this.propPrefix + "bdos.autoload",
 		this.btnAutoLoadBDOS.isSelected() );
     this.fldAltROM.applyInput( props, selected );
     this.fldAltFont.applyInput( props, selected );
@@ -167,7 +167,7 @@ public class PCMSettingsFld extends AbstractSettingsFld
     this.btnAutoLoadBDOS.setSelected(
 			EmuUtil.getBooleanProperty(
 				props,
-				this.propPrefix + "auto_load_bdos",
+				this.propPrefix + "bdos.autoload",
 				true ) );
     this.fldAltROM.updFields( props );
     this.fldAltFont.updFields( props );


### PR DESCRIPTION
Add a new file setting dialog for RAM images. Add a new property for PC/M to use a external RAM image to load automatically on reset as BDOS at address 0xD000.
